### PR TITLE
Fix deprecation warning for MPI.mpiexec

### DIFF
--- a/src/MPIClusterManagers.jl
+++ b/src/MPIClusterManagers.jl
@@ -4,7 +4,7 @@ export MPIManager, launch, manage, kill, procs, connect, mpiprocs, @mpi_do, Tran
 
 using Distributed, Serialization
 import MPI
-const mpiexec = isdefined(MPI, :mpiexec) ? MPI.mpiexec : "mpiexec"
+const mpiexec = isdefined(MPI, :mpiexec_path) ? MPI.mpiexec_path : "mpiexec"
 
 include("mpimanager.jl")
 


### PR DESCRIPTION
See https://github.com/JuliaParallel/MPI.jl/pull/341