### PR TITLE
Fix and re-add missing code for examples

### DIFF
--- a/examples/01-hello-impl.jl
+++ b/examples/01-hello-impl.jl
@@ -1,0 +1,5 @@
+function do_hello()
+    comm = MPI.COMM_WORLD
+    println("Hello world, I am $(MPI.Comm_rank(comm)) of $(MPI.Comm_size(comm))")
+    MPI.Barrier(comm)
+end

--- a/examples/02-broadcast-impl.jl
+++ b/examples/02-broadcast-impl.jl
@@ -1,0 +1,47 @@
+using Printf
+
+function do_broadcast()
+    comm = MPI.COMM_WORLD
+
+    if MPI.Comm_rank(comm) == 0
+        println(repeat("-",78))
+        println(" Running on $(MPI.Comm_size(comm)) processes")
+        println(repeat("-",78))
+    end
+
+    MPI.Barrier(comm)
+
+    N = 5
+    root = 0
+
+    if MPI.Comm_rank(comm) == root
+        A = [1:N;] * (1.0 + im*2.0)
+    else
+        A = Array{ComplexF64}(undef, N)
+    end
+
+    MPI.Bcast!(A,length(A), root, comm)
+
+    @printf("[%02d] A:%s\n", MPI.Comm_rank(comm), A)
+
+    if MPI.Comm_rank(comm) == root
+        B = Dict("foo" => "bar")
+    else
+        B = nothing
+    end
+
+    B = MPI.bcast(B, root, comm)
+    @printf("[%02d] B:%s\n", MPI.Comm_rank(comm), B)
+
+
+    # This example is currently broken
+
+    # if MPI.Comm_rank(comm) == root
+    #     f = x -> x^2 + 2x - 1
+    # else
+    #     f = nothing
+    # end
+
+    # f = MPI.bcast(f, root, comm)
+    # @printf("[%02d] f(3):%d\n", MPI.Comm_rank(comm), f(3))
+end

--- a/examples/03-reduce-impl.jl
+++ b/examples/03-reduce-impl.jl
@@ -1,0 +1,16 @@
+using Printf
+
+function do_reduce()
+    comm = MPI.COMM_WORLD
+
+    MPI.Barrier(comm)
+
+    root = 0
+    r = MPI.Comm_rank(comm)
+
+    sr = MPI.Reduce(r, MPI.SUM, root, comm)
+
+    if(MPI.Comm_rank(comm) == root)
+        @printf("sum of ranks: %s\n", sr)
+    end
+end

--- a/examples/04-sendrecv-impl.jl
+++ b/examples/04-sendrecv-impl.jl
@@ -1,0 +1,30 @@
+function do_sendrecv()
+
+    comm = MPI.COMM_WORLD
+
+    MPI.Barrier(comm)
+
+    rank = MPI.Comm_rank(comm)
+    size = MPI.Comm_size(comm)
+
+    dst = mod(rank+1, size)
+    src = mod(rank-1, size)
+
+    N = 4
+
+    send_mesg = Array{Float64}(undef, N)
+    recv_mesg = Array{Float64}(undef, N)
+
+    fill!(send_mesg, Float64(rank))
+
+    rreq = MPI.Irecv!(recv_mesg, src,  src+32, comm)
+
+    println("$rank: Sending   $rank -> $dst = $send_mesg")
+    sreq = MPI.Isend(send_mesg, dst, rank+32, comm)
+
+    stats = MPI.Waitall!([rreq, sreq])
+
+    println("$rank: Receiving $src -> $rank = $recv_mesg")
+
+    MPI.Barrier(comm)
+end

--- a/examples/cman-transport.jl
+++ b/examples/cman-transport.jl
@@ -1,22 +1,23 @@
-using MPI, Distributed
+using MPIClusterManagers, Distributed
+import MPI
 
 MPI.Init()
 rank = MPI.Comm_rank(MPI.COMM_WORLD)
 size = MPI.Comm_size(MPI.COMM_WORLD)
 
-include("01-hello-impl.jl")
-include("02-broadcast-impl.jl")
-include("03-reduce-impl.jl")
-include("04-sendrecv-impl.jl")
+# include("01-hello-impl.jl")
+# include("02-broadcast-impl.jl")
+# include("03-reduce-impl.jl")
+# include("04-sendrecv-impl.jl")
 
 if length(ARGS) == 0
     println("Please specify a transport option to use [MPI|TCP]")
     MPI.Finalize()
     exit(1)
 elseif ARGS[1] == "TCP"
-    manager = MPI.start_main_loop(TCP_TRANSPORT_ALL) # does not return on worker
+    manager = MPIClusterManagers.start_main_loop(TCP_TRANSPORT_ALL) # does not return on worker
 elseif ARGS[1] == "MPI"
-    manager = MPI.start_main_loop(MPI_TRANSPORT_ALL) # does not return on worker
+    manager = MPIClusterManagers.start_main_loop(MPI_TRANSPORT_ALL) # does not return on worker
 else
     println("Valid transport options are [MPI|TCP]")
     MPI.Finalize()
@@ -56,4 +57,4 @@ println("$t seconds for $nloops loops of send-recv of array size $n")
 # print("EXAMPLE: SENDRECV\n")
 # @mpi_do manager do_sendrecv()
 
-MPI.stop_main_loop(manager)
+MPIClusterManagers.stop_main_loop(manager)

--- a/examples/juliacman.jl
+++ b/examples/juliacman.jl
@@ -1,12 +1,14 @@
 # Note: Run this script without using `mpirun`
 
-using MPI, Distributed
+using MPIClusterManagers, Distributed
 using LinearAlgebra: svd
 
 manager = MPIManager(np=4)
 addprocs(manager)
 
 println("Added procs $(procs())")
+
+@everywhere import MPI
 
 println("Running 01-hello as part of a Julia cluster")
 @mpi_do manager (include("01-hello-impl.jl"); do_hello())


### PR DESCRIPTION
Examples were broken because the `*-impl.jl` files had not been moved and not all references to `MPI` that should now be `MPIClusterManagers` had been changed.

Note that broadcasting a function appears to be currently broken, so the [corresponding code](https://github.com/tribut/MPIClusterManagers.jl/blob/bf048ec158a2395bff7946fc85db8160d60d7fb1/examples/02-broadcast-impl.jl#L39-L46) has been commented out.

Obviously the `cman-transport.jl` example is still broken on Julia 1.3+ due to https://github.com/JuliaParallel/MPIClusterManagers.jl/issues/9.