### PR TITLE
Use more recent OSX image in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: julia
 dist: trusty
+osx_image: xcode11.4
 
 os:
   - linux


### PR DESCRIPTION
I think this fixed some things for MPI and Elemental, maybe it'll work for this one too.