### PR TITLE
CI: Cancel outdated PR builds when new commits are pushed to a PR branch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,11 @@ on:
       - master
     tags: '*'
   pull_request:
+concurrency:
+  # Skip intermediate builds: all builds except for builds on the `master` branch
+  # Cancel intermediate builds: only pull request builds
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This allows us to save some CI time.

Basically, if a new commit is pushed to the branch of an existing PR, then CI will start running on that newest commit, and any CI jobs that are still running on old commits (of that same PR) will be canceled.